### PR TITLE
Feature multiplex

### DIFF
--- a/lib/cl/client.lisp
+++ b/lib/cl/client.lisp
@@ -21,7 +21,7 @@
 ;;; specific language governing permissions and limitations
 ;;; under the License.
 
-
+(defvar *current-service* nil)
 
 (defgeneric client (location &key protocol direction element-type &allow-other-keys)
   (:method ((location puri:uri) &rest initargs &key (direction :io) (element-type 'unsigned-byte et-s) &allow-other-keys)
@@ -76,3 +76,7 @@
     (unwind-protect (funcall op protocol)
       (when (open-stream-p protocol)
         (close protocol)))))
+
+(defmacro with-service (service &body body)
+  `(let ((*current-service* (service-identifier ,service)))
+     ,@body))

--- a/lib/cl/definition-operators.lisp
+++ b/lib/cl/definition-operators.lisp
@@ -353,7 +353,14 @@
          #+ccl (ccl::record-arglist ',name '(protocol ,@parameter-names))
          (defmethod ,name ((,gprot protocol) ,@(mapcar #'list parameter-names type-names))
            ,@(when documentation `(,documentation))
-           (stream-write-message-begin ,gprot ,identifier 'call
+           (stream-write-message-begin ,gprot
+				       (if thrift.implementation::*current-service*
+					   (concatenate 'string
+							thrift.implementation::*current-service*
+							":"
+							,identifier)
+					    ,identifier)
+				       'call
                                        (protocol-next-sequence-number ,gprot))
            ;; use the respective args structure as a template to generate the message
            (stream-write-struct ,gprot (thrift:list ,@(mapcar #'(lambda (id name) `(cons ,id ,name)) parameter-ids parameter-names))

--- a/lib/cl/package.lisp
+++ b/lib/cl/package.lisp
@@ -56,7 +56,7 @@
    :class-identifier
    :class-not-found
    :class-not-found-error
-   :client with-client
+   :client :with-client :with-service
    :def-constant
    :def-enum
    :def-exception

--- a/lib/cl/thrift.asd
+++ b/lib/cl/thrift.asd
@@ -34,6 +34,7 @@
  services protocol."
   :serial t
   :components ((:file "package")
+	       (:file "util")
                (:file "symbols")
                (:file "types")
                (:file "parameters")

--- a/lib/cl/util.lisp
+++ b/lib/cl/util.lisp
@@ -1,0 +1,8 @@
+(in-package :org.apache.thrift.implementation)
+
+(defun split-once (delimiter sequence)
+  "Find the first instance of DELIMITER and split the sequence into two."
+  (let ((position (position delimiter sequence)))
+    (if (null position) (error "The expected delimiter was not found."))
+    (values (subseq sequence 0 position)
+	    (subseq sequence (1+ position)))))


### PR DESCRIPTION
Multiplex support for both the client and the server, according to [this Apache issue](https://issues.apache.org/jira/browse/THRIFT-563).

For the server side, you simply pass a list of services rather than a single service to the `thrift:serve` function.

```lisp
CL-USER> (thrift:serve #u"thrift://127.0.0.1:9090" (list thrift.test:thrift-test thrift.test:second-service))
```

For the client side, you currently have to use the new `with-service` macro so that the protocol "knows" to append the service name to requests.

```lisp
CL-USER> (thrift:with-client (prot #u"thrift://127.0.0.1:9090") (thrift:with-service thrift.test:second-service (thrift.test:secondtest-string prot "bleh")))
```