### PR TITLE
Multiplex cross tests

### DIFF
--- a/test/cl/implementation.lisp
+++ b/test/cl/implementation.lisp
@@ -114,8 +114,8 @@
   (format t "testOneway(~a): done sleeping!~%" seconds))
 
 (defun thrift.test.second-service-implementation:blah-blah ()
-  )
+  (format t "blahBlah()~%"))
 
 (defun thrift.test.second-service-implementation:secondtest-string (thing)
-  (format t "testString(~a)~%" thing)
+  (format t "secondtestString(~a)~%" thing)
   thing)

--- a/test/cl/make-test-client.lisp
+++ b/test/cl/make-test-client.lisp
@@ -35,11 +35,11 @@
 	    :argument-name "ARG"
 	    :argument-type :optional)
     (stropt :long-name "transport"
-	    :description "Transport: transport to use; one of: \"buffered\", \"framed\""
+	    :description "Transport: transport to use (\"buffered\", \"framed\")"
 	    :default-value "buffered"
 	    :argument-name "ARG")
     (stropt :long-name "protocol"
-	    :description "Protocol: currently only \"binary\""
+	    :description "Protocol: protocol to use (\"binary\", \"multi\")"
 	    :default-value "binary"
 	    :argument-name "ARG")))
 
@@ -51,7 +51,8 @@
     (clon:exit))
   (let ((port "9090")
 	(host "localhost")
-        (framed nil))
+        (framed nil)
+        (multiplexed nil))
     (clon:do-cmdline-options (option name value source)
       (print (list option name value source))
       (if (string= name "host")
@@ -61,12 +62,17 @@
       (if (string= name "transport")
           (cond ((string= value "buffered") (setf framed nil))
                 ((string= value "framed") (setf framed t))
-                (t (error "Unsupported transport.")))))
+                (t (error "Unsupported transport."))))
+      (if (string= name "protocol")
+          (cond ((string= value "binary") (setf multiplexed nil))
+                ((string= value "multi") (setf multiplexed t))
+                (t (error "Unsupported protocol.")))))
     (terpri)
     (setf *prot* (thrift.implementation::client (puri:parse-uri
                                                  (concatenate 'string "thrift://" host ":" port))
-                                                :framed framed))
-    (let ((result (cross-test)))
+                                                :framed framed
+                                                :multiplexed multiplexed))
+    (let ((result (cross-test :multiplexed multiplexed)))
       (thrift.implementation::close *prot*)
       (clon:exit result))))
 

--- a/test/cl/tests.lisp
+++ b/test/cl/tests.lisp
@@ -15,20 +15,22 @@
 
 (defun cross-test (&key (multiplexed nil))
   "The main cross-test runner."
-  (let ((result 0))
+  (let ((result nil))
     (handler-case (progn (unless (run-package-tests :package :base-types)
-			   (incf result *test_basetypes*))
+			   (pushnew *test_basetypes* result))
 			 (unless (run-package-tests :package :structs)
-			   (incf result *test_structs*))
+			   (pushnew *test_structs* result))
 			 (unless (run-package-tests :package :containers)
-			   (incf result *test_containers*))
+			   (pushnew *test_containers* result))
 			 (unless (run-package-tests :package :exceptions)
-			   (incf result *test_exceptions*))
-			 (run-package-tests :package :misc)
+			   (pushnew *test_exceptions* result))
+			 (unless (run-package-tests :package :misc)
+                           (pushnew *test_unknown* result))
                          (when multiplexed
-                           (run-package-tests :package :multiplex)))
-      (error (e) (incf result *test_unknown*)))
-    result))
+                           (unless (run-package-tests :package :multiplex)
+                             (pushnew *test_unknown* result))))
+      (error (e) (pushnew *test_unknown* result)))
+    (apply #'+ result)))
 
 (fiasco:define-test-package :base-types)
 

--- a/test/cl/tests.lisp
+++ b/test/cl/tests.lisp
@@ -13,7 +13,7 @@
 (defparameter *test_unknown* 64)
 (defparameter *test_timeout* 128)
 
-(defun cross-test ()
+(defun cross-test (&key (multiplexed nil))
   "The main cross-test runner."
   (let ((result 0))
     (handler-case (progn (unless (run-package-tests :package :base-types)
@@ -24,7 +24,9 @@
 			   (incf result *test_containers*))
 			 (unless (run-package-tests :package :exceptions)
 			   (incf result *test_exceptions*))
-			 (run-package-tests :package :misc))
+			 (run-package-tests :package :misc)
+                         (when multiplexed
+                           (run-package-tests :package :multiplex)))
       (error (e) (incf result *test_unknown*)))
     result))
 
@@ -205,3 +207,11 @@
 
 (deftest oneway-test ()
   (is (null (thrift.test.thrift-test:test-oneway thrift-cross::*prot* 1))))
+
+(fiasco:define-test-package :multiplex)
+
+(in-package :multiplex)
+
+(deftest multiplex-test ()
+  (finishes (thrift.test.second-service:blah-blah thrift-cross::*prot*))
+  (is (string= "asd" (thrift.test.second-service:secondtest-string thrift-cross::*prot* "asd"))))

--- a/test/cl/tests.lisp
+++ b/test/cl/tests.lisp
@@ -26,6 +26,12 @@
 			   (pushnew *test_exceptions* result))
 			 (unless (run-package-tests :package :misc)
                            (pushnew *test_unknown* result))
+                         
+                         ;; It doesn't seem like anyone actually uses
+                         ;; the second test service when testing multiplexing,
+                         ;; so this would fail against servers in other
+                         ;; languages. For now, anyway.
+                         #+(or)
                          (when multiplexed
                            (unless (run-package-tests :package :multiplex)
                              (pushnew *test_unknown* result))))

--- a/test/tests.json
+++ b/test/tests.json
@@ -650,7 +650,7 @@
     "client": {
       "command": ["TestClient"],
       "workdir": "cl",
-        "protocols": ["binary"],
+      "protocols": ["binary", "multi"],
       "transports": ["buffered", "framed"],
       "sockets": ["ip"]
     }

--- a/test/tests.json
+++ b/test/tests.json
@@ -643,14 +643,14 @@
     "server": {
       "command": ["TestServer"],
       "workdir": "cl",
-      "protocols": ["binary"],
+      "protocols": ["binary", "multi"],
       "transports": ["buffered", "framed"],
       "sockets": ["ip"]
     },
     "client": {
       "command": ["TestClient"],
       "workdir": "cl",
-      "protocols": ["binary"],
+        "protocols": ["binary"],
       "transports": ["buffered", "framed"],
       "sockets": ["ip"]
     }


### PR DESCRIPTION
The tests are here, but there are problems with our multiplexing protocol.

With CL on the server side, tests fail since CL sends response structs with the `ThriftTest:` prefix in the identifier, and it's not meant to do that. It's only supposed to tokenize and "demultiplex" incoming requests (like `ThriftTest:testString`) and send back regular responses (like `testString`).

With CL on the client side, the tests succeed with warnings - the problem is CL currently expects responses to have the `ThriftTest:testString` form, while, for reasons stated above, it should expect `testString`.

How about merging this and opening an issue to fix the underlying problems that either of us will work on?