### PR TITLE
CCL support

### DIFF
--- a/lib/cl/conditions.lisp
+++ b/lib/cl/conditions.lisp
@@ -38,13 +38,14 @@
 
 ;;; abstract exceptions
 
-(define-condition thrift-error (simple-error)
-  ((type
-    :initform *protocol-ex-unknown*
-    :reader thrift-error-type))
-  (:report (lambda (error stream)
-             (apply #'format stream (thrift-error-format-control error)
-                    (thrift-error-format-arguments error)))))
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (define-condition thrift-error (simple-error)
+    ((type
+      :initform *protocol-ex-unknown*
+      :reader thrift-error-type))
+    (:report (lambda (error stream)
+               (apply #'format stream (thrift-error-format-control error)
+                      (thrift-error-format-arguments error))))))
 
 (defgeneric thrift-error-format-control (error)
   (:method ((error thrift-error))
@@ -54,9 +55,10 @@
   (:method ((error thrift-error))
     (list (type-of error) (thrift-error-type error))))
 
-(define-condition protocol-error (thrift-error)
-  ((protocol :initarg :protocol :initform nil
-             :reader protocol-error-protocol)))
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (define-condition protocol-error (thrift-error)
+    ((protocol :initarg :protocol :initform nil
+               :reader protocol-error-protocol))))
 
 (defmethod thrift-error-format-control ((error protocol-error))
   (concatenate 'string (call-next-method)
@@ -68,9 +70,10 @@
 
 (define-condition transport-error (thrift-error) ())
 
-(define-condition application-error (protocol-error)
-  ((type :initform *application-ex-unknown*)
-   (condition :initform nil :initarg :condition :reader application-error-condition)))
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (define-condition application-error (protocol-error)
+    ((type :initform *application-ex-unknown*)
+     (condition :initform nil :initarg :condition :reader application-error-condition))))
 
 (defmethod thrift-error-format-control ((error application-error))
   (concatenate 'string (call-next-method)

--- a/lib/cl/test/definition-operators.lisp
+++ b/lib/cl/test/definition-operators.lisp
@@ -63,11 +63,7 @@
     (is (equal (test-struct-too-field3 struct) "string value"))
     (is (not (slot-boundp struct 'field2)))
     (is (equal (test-struct-too-field1 struct) -1))
-    (is (typep (nth-value 1 (ignore-errors (setf (test-struct-too-field2 struct) 1.1)))
-               ;; some implementation may not constrain
-               ;; some signal a type error
-               #+ccl 'type-error
-               #+sbcl 'null))           ; how to enable slot type checks?
+    (is (typep (nth-value 1 (ignore-errors (setf (test-struct-too-field1 struct) 1.1))) 'null))
     (mapc #'(lambda (method) (remove-method (c2mop:method-generic-function method) method))
           (c2mop:specializer-direct-methods (find-class 'test-struct-too)))
     (setf (find-class 'test-struct-too) nil)))

--- a/lib/cl/vector-protocol.lisp
+++ b/lib/cl/vector-protocol.lisp
@@ -42,7 +42,7 @@
     :accessor stream-force-output-hook
     :documentation "A function of one argument, the stream, called as the
      base implementation of stream-force-output.")
-   #+(or CMU sbcl lispworks) (direction :initarg :direction)
+   (direction :initarg :direction)
    )
   (:default-initargs
     #+CormanLisp :element-type #+CormanLisp 'character))

--- a/lib/cl/vector-protocol.lisp
+++ b/lib/cl/vector-protocol.lisp
@@ -1,5 +1,26 @@
 (in-package #:org.apache.thrift.implementation)
 
+;;; This file defines the abstract '`protocol` layer for the `org.apache.thrift` library.
+;;;
+;;; copyright 2010 [james anderson](james.anderson@setf.de)
+;;;
+;;; Licensed to the Apache Software Foundation (ASF) under one
+;;; or more contributor license agreements. See the NOTICE file
+;;; distributed with this work for additional information
+;;; regarding copyright ownership. The ASF licenses this file
+;;; to you under the Apache License, Version 2.0 (the
+;;; "License"); you may not use this file except in compliance
+;;; with the License. You may obtain a copy of the License at
+;;;
+;;;   http://www.apache.org/licenses/LICENSE-2.0
+;;;
+;;; Unless required by applicable law or agreed to in writing,
+;;; software distributed under the License is distributed on an
+;;; "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+;;; KIND, either express or implied. See the License for the
+;;; specific language governing permissions and limitations
+;;; under the License.
+
 ;;; define a binary stream to wrap a vector for use in tests.
 ;;; adapted from the cl-xml version to restrict i/o to unsigned byte operations.
 ;;; this version uses a signed byte stream, as that's the basis of the thrift binary transport

--- a/test/cl/make-test-client.lisp
+++ b/test/cl/make-test-client.lisp
@@ -5,7 +5,7 @@
 (load (merge-pathnames "externals/bundle.lisp" *load-truename*))
 (asdf:load-system :net.didierverna.clon)
 (asdf:load-system :fiasco)
-(asdf:load-asd (merge-pathnames "gen-cl/ThriftTest/thrift-gen-ThriftTest.asd"))
+(asdf:load-asd (merge-pathnames "gen-cl/ThriftTest/thrift-gen-ThriftTest.asd" *load-truename*))
 (asdf:load-system :thrift-gen-thrifttest)
 
 (net.didierverna.clon:nickname-package)

--- a/test/cl/make-test-server.lisp
+++ b/test/cl/make-test-server.lisp
@@ -4,9 +4,9 @@
 (load (merge-pathnames "../../lib/cl/load-locally.lisp" *load-truename*))
 (load (merge-pathnames "externals/bundle.lisp" *load-truename*))
 (asdf:load-system :net.didierverna.clon)
-(asdf:load-asd (merge-pathnames "gen-cl/ThriftTest/thrift-gen-ThriftTest.asd"))
+(asdf:load-asd (merge-pathnames "gen-cl/ThriftTest/thrift-gen-ThriftTest.asd" *load-truename*))
 (asdf:load-system :thrift-gen-thrifttest)
-(load (merge-pathnames "implementation.lisp"))
+(load (merge-pathnames "implementation.lisp" *load-truename*))
 
 (net.didierverna.clon:nickname-package)
 


### PR DESCRIPTION
Unfinished (I got stuck on a type-checking bug), but it's a start. Doesn't seem to introduce any regressions with SBCL. It's at least possible to load the Thrift library with CCL and successfully run self-tests.

Let's merge this now so I can do some cleaning up on top of it. Hopefully we'll come back to the issue.